### PR TITLE
卡池记录同步问题的临时修复方案 Temporary Fix: DW/Sunborn Server Auth Workaround via mitmproxy

### DIFF
--- a/gfl2_token_extractor.py
+++ b/gfl2_token_extractor.py
@@ -1,0 +1,102 @@
+import json
+import os
+import sys 
+from mitmproxy import ctx, http
+from mitmproxy.tools.main import mitmdump 
+
+# --- Configuration ---
+# For now, targeting US specifically as it's the one confirmed affected.
+TARGET_HOSTS = [
+    "gf2-gacha-record-us.sunborngame.com",
+    # Add other oversea gacha domains here if they also become affected
+    # "gf2-gacha-record-intl.sunborngame.com",
+    # "gf2-gacha-record-jp.sunborngame.com",
+]
+TARGET_PATH_PREFIX = "/list" # The common path for the gacha list endpoint
+OUTPUT_FILE = "gacha_session_info.json"
+
+# To prevent multiple writes in a single mitmproxy session.
+#info_saved_this_session = False
+
+class GachaInfoSaver:
+    def request(self, flow: http.HTTPFlow) -> None:
+        global info_saved_this_session
+        #if info_saved_this_session:
+        #    return
+
+        req = flow.request
+
+        if req.host in TARGET_HOSTS and \
+           req.path.startswith(TARGET_PATH_PREFIX) and \
+           req.method == "POST":
+
+            try:
+                # Looking for the initial request for a banner type
+                form_data = req.urlencoded_form
+                if "next" not in form_data and "type_id" in form_data:
+                    ctx.log.info(f"Potential initial gacha request detected: {req.pretty_url}")
+
+                    access_token = req.headers.get("Authorization", None)
+                    # req.pretty_url gives the full URL including scheme, host, path, and query parameters
+                    full_gacha_url = req.pretty_url
+
+                    if access_token and full_gacha_url:
+                        data_to_save = {
+                            "FullGachaRecordUrl": full_gacha_url,
+                            "AccessToken": access_token,
+                            "UidString": "REPLACE_WITH_YOUR_UID"
+                        }
+
+                        # Save the file in the same directory as the script for simplicity
+                        script_dir = os.path.dirname(os.path.abspath(__file__))
+                        output_path = os.path.join(script_dir, OUTPUT_FILE)
+
+                        with open(output_path, "w") as f:
+                            json.dump(data_to_save, f, indent=4)
+                        
+                        print("-" * 70)
+                        print(f"[SUCCESS] Gacha session info saved to: {output_path}")
+                        print(f"  FullGachaRecordUrl: {full_gacha_url}")
+                        print(f"  AccessToken: {access_token[:20]}... (truncated for display)")
+                        print(f"  UidString: PLEASE OPEN '{OUTPUT_FILE}' AND REPLACE 'REPLACE_WITH_YOUR_UID' with your actual game UID.")
+                        print("-" * 70)
+                        print("[IMPORTANT]")
+                        print("you MUST turn OFF the system proxy settings now that the script is finished")
+                        print("or your internet connection will NOT work correctly")
+                        print("(Windows: Settings > Network & Internet > Manual proxy)")
+                        print("-" * 70)
+                        print("mitmproxy will attempt to shut down now...")
+                        #info_saved_this_session = True # Prevent further writes in this session
+                        ctx.master.shutdown()
+                    else:
+                        if not access_token:
+                            ctx.log.warn("Authorization header missing in the targeted gacha request.")
+                        # full_gacha_url should always be present if req.pretty_url works
+            except Exception as e:
+                # Log any errors during form data processing or file writing
+                ctx.log.error(f"Error processing request or saving gacha info: {e}")
+
+addons = [GachaInfoSaver()]
+
+def main():
+    print("-" * 50)
+    print("Starting mitmdump with GachaInfoSaver addon...")
+    print(f"Ensure your system/game proxy is set to http://127.0.0.1:8080")
+    print(f"And the mitmproxy CA certificate is installed and trusted.")
+    print(f"Trigger the gacha history view in your game for the US server.")
+    print(f"The script will capture the details and save them to '{OUTPUT_FILE}'.")
+    print("Press Ctrl+C to stop mitmdump if it doesn't shut down automatically.")
+    print("-" * 50)
+    
+    # Can add filters to the command line here.
+    mitm_args = ['-s', __file__]
+    
+    try:
+        mitmdump(mitm_args)
+    except KeyboardInterrupt:
+        print("\nmitmdump stopped by user.")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    # This allows the script to be run directly using `python save_gacha_info.py`
+    main()

--- a/service/GetUserInfo.go
+++ b/service/GetUserInfo.go
@@ -1,13 +1,52 @@
 package service
 
 import (
-	"github.com/pkg/errors"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 )
+
+// UserProvidedConfig struct to match gacha_session_info.json
+type UserProvidedConfig struct {
+	FullGachaRecordUrl string `json:"FullGachaRecordUrl"`
+	AccessToken        string `json:"AccessToken"`
+	UidString          string `json:"UidString"`
+}
+
+const CONFIG_FILE_NAME = "gacha_session_info.json"
+
+// loadUserConfig reads and parses the JSON configuration file.
+func loadUserConfig(configFilePath string) (*UserProvidedConfig, error) {
+	data, err := os.ReadFile(configFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.Wrapf(err, "config file '%s' not found", configFilePath)
+		}
+		return nil, errors.Wrapf(err, "failed to read config file '%s'", configFilePath)
+	}
+
+	var config UserProvidedConfig
+	err = json.Unmarshal(data, &config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal config data from file '%s'", configFilePath)
+	}
+
+	if config.FullGachaRecordUrl == "" {
+		return nil, errors.New("config file error: missing 'FullGachaRecordUrl'")
+	}
+	if config.AccessToken == "" {
+		return nil, errors.New("config file error: missing 'AccessToken'")
+	}
+	if config.UidString == "" || strings.ToUpper(config.UidString) == "REPLACE_WITH_YOUR_UID" {
+		return nil, errors.New("config file error: 'UidString' is placeholder or missing. Please edit '" + CONFIG_FILE_NAME + "'.")
+	}
+	return &config, nil
+}
 
 func GetUserInfoCN() (*GameUserInfo, error) {
 	userHome, err := os.UserHomeDir()
@@ -69,8 +108,82 @@ func GetUserInfoCN() (*GameUserInfo, error) {
 }
 
 func GetUserInfoOS() (*GameUserInfo, error) {
-	userHome, err := os.UserHomeDir()
-	if err != nil {
+	// Load Auth Info from JSON config file
+	exePath, errExe := os.Executable()
+	configFilePath := CONFIG_FILE_NAME // Default to current dir
+	if errExe != nil {
+
+	} else {
+		configFilePath = filepath.Join(filepath.Dir(exePath), CONFIG_FILE_NAME)
+	}
+
+	authConfig, errConfig := loadUserConfig(configFilePath)
+	/* 	if errConfig != nil {
+		fmt.Printf("DEBUG: loadUserConfig for '%s' failed: %v\n", configFilePath, errConfig)
+	} */
+	if errConfig == nil && authConfig != nil {
+		// User config loaded successfully
+		uid, parseErr := strconv.ParseUint(authConfig.UidString, 10, 64)
+		if parseErr != nil {
+			return nil, errors.Wrapf(parseErr, "Failed to parse UidString '%s' from JSON config (OS)", authConfig.UidString)
+		}
+
+		gachaRecordUrlFromConfig := authConfig.FullGachaRecordUrl
+		var server gameServer
+
+		urlLowerConfig := strings.ToLower(gachaRecordUrlFromConfig)
+		switch {
+		case strings.Contains(urlLowerConfig, "gf2-gacha-record-us"):
+			server = GameServerUS
+		case strings.Contains(urlLowerConfig, "gf2-gacha-record-intl"):
+			server = GameServerGlobal
+		case strings.Contains(urlLowerConfig, "gf2-gacha-record-jp"):
+			server = GameServerJP
+		case strings.Contains(urlLowerConfig, "gf2-gacha-record-kr"):
+			server = GameServerKR
+		case strings.Contains(urlLowerConfig, "gf2-gacha-record-asia"):
+			server = GameServerAsia
+		default:
+			return nil, errors.Errorf("Failed to determine a valid Oversea server from JSON config URL: %s", gachaRecordUrlFromConfig)
+		}
+
+		// GameDataDir extraction logic (this is still available in Player.log)
+		var gameDataDir string
+		userHome, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+
+		} else {
+			logDataBytes, readLogErr := os.ReadFile(filepath.Join(userHome, gameLogPathOversea))
+			if readLogErr != nil {
+
+			} else {
+				regexpGameDataDir, compErrGD := regexp.Compile(exprGameDataDir)
+				if compErrGD != nil {
+					return nil, errors.New("Internal error: Failed to compile exprGameDataDir for GameDataDir") // Should ideally not happen
+				} else {
+					resultGameDataDir := regexpGameDataDir.FindSubmatch(logDataBytes)
+					if resultGameDataDir == nil {
+
+					} else {
+						gameDataDir = filepath.Join(string(resultGameDataDir[1]), "LocalCache/Data")
+					}
+				}
+			}
+		}
+
+		userInfo := &GameUserInfo{
+			Uid:             uid,
+			GameServer:      server,
+			GameDataDir:     gameDataDir,
+			GameAccessToken: authConfig.AccessToken,
+			GachaRecordUrl:  authConfig.FullGachaRecordUrl,
+		}
+		return userInfo, nil
+	}
+
+	// Fallback: Use original Player.log parsing method since it still works for Haoplay
+	userHome, homeErr := os.UserHomeDir()
+	if homeErr != nil {
 		return nil, errors.New("Failed to get user home dir")
 	}
 


### PR DESCRIPTION
## 通过抓包临时修复散爆直营服的同步记录功能

由于近期的[安全更新](https://www.reddit.com/r/GirlsFrontline2/comments/1krn8ij/psa_your_password_to_gfl2_is_being_logged_in/)导致无法再从日志文件中直接获取必要的认证信息（AccessToken，GachaRecordUrl，以及UID），此修复需要借助的外部的网络抓包工具 (mitmproxy) ，配合Python脚本`gfl2_token_extractor.py`来半自动抓取这些认证信息。Python脚本会将信息保存至`gacha_session_info.json`，然后用户需要手动在此文件中填入游戏UID。

后端的`GetUserInfoOS()` 在获取用户信息时，将：
1.  优先尝试读取并解析此 `gacha_session_info.json` 文件。若成功，则使用文件中的信息。
2.  若JSON文件加载失败 （如文件不存在、格式错误或UID未填写），程序将回退至原有的 `Player.log` 解析逻辑。

**针对其他服务器的影响:**
* 国服相关的同步功能没有改动，国服的同步功能应该还是失效状态。心动服/Haoplay似乎不受这次更新的影响，所以原有的解析方式仍然有效（未测试）。

只是作为正式解决方案之前的临时修复，请随意修改或关闭这个pr。
以下是关于编译临时可执行文件的步骤说明。

<details>
<summary><strong>中文说明 (点击展开)</strong></summary>

---
**安装软件：**
1.  安装 **Git**: [git-scm.com/downloads](https://git-scm.com/downloads/)
2.  安装 **Go** 语言环境: [go.dev/dl/](https://go.dev/dl/)
3.  安装 **Wails CLI**: [wails.io/docs/gettingstarted/installation](https://wails.io/docs/gettingstarted/installation)
4.  安装 **Python 3**: [python.org/downloads/](https://www.python.org/downloads/)
5.  安装 **`mitmproxy`**: 打开终端/命令行提示符，运行 `pip install mitmproxy`。

---

**第一部分：编译软件**

1.  **创建新文件夹:**
    在电脑上创建一个新的空文件夹 (例如 "ElmoBeacon-tempfix"，下文会使用”新文件夹“称呼)。如果已有旧版本的 `ElmoBeacon.db` 文件，建议将其复制到这个新文件夹中，这样旧的抽卡记录会继承，减少读取时间。
2.  **克隆此修复分支的仓库:**
    *   在新文件夹中打开终端/命令行提示符（在文件管理器的路径栏输入`cmd`）。
    *   运行以下命令:
        ```bash
        git clone -b temp-fix-us-auth https://github.com/vitafinn/ElmoBeacon.git
        ```
3.  **编译应用程序:**
    *   进入 `ElmoBeacon` 目录: `cd ElmoBeacon`
    *   运行Wails编译命令:
        ```bash
        wails build
        ```
4.  **移动可执行文件:**
    *   编译完成后，进入 `ElmoBeacon\build\bin\` 目录。
    *   将生成的 `ElmoBeacon.exe` 文件移动到新文件夹最上层（和`ElmoBeacon`文件夹并排）。

---
**第二部分**

5.  **获取mitmproxy配套的辅助脚本:**
    *   从刚克隆的仓库（ElmoBeacon文件夹）中找到`gfl2_token_extractor.py`，复制到`ElmoBeacon.exe`同一目录下
    *   或者：从以下链接下载 `gfl2_token_extractor.py` 脚本：[https://gist.github.com/vitafinn/a0aa2136d58719040731f18629d60bd4](https://gist.github.com/vitafinn/a0aa2136d58719040731f18629d60bd4)
        *   将其保存在`ElmoBeacon.exe`同一目录下。

7.  **运行辅助脚本:**
    *   在终端中 (确保当前路径是`gfl2_token_extractor.py`所在的目录)，运行：
        ```bash
        python gfl2_token_extractor.py
        ```
    *   该脚本会启动 `mitmproxy` 的命令行工具 `mitmdump`。

8.  **配置系统代理和证书:**
    *   **代理设置:** 确保系统的 HTTP/HTTPS 代理服务器地址设置为 `127.0.0.1`，端口设置为 `8080`。
        *   *(Windows步骤：设置 > 网络和互联网 > 代理 > 手动设置代理)*
    *   **证书安装:** 在 `mitmproxy` （python脚本）运行时，打开浏览器访问 `http://mitm.it`。按照页面提示下载并安装 `mitmproxy` 的CA证书。
        *   *(或手动安装: [docs.mitmproxy.org/stable/concepts/certificates](https://docs.mitmproxy.org/stable/concepts/certificates/#installing-the-mitmproxy-ca-certificate-manually))*

9.  **在游戏中触发卡池记录请求:**
    启动追放客户端（散爆服），并进入任意一个卡池的抽取记录界面。

10.  **文件生成:**
    *   运行中的Python脚本会抓取并打印捕获到的信息，同时在新文件夹中保存一个名为 `gacha_session_info.json` 的文件。
    *   之后 `mitmproxy` 会自动关闭。（此时电脑会没有网络，见第12步）

11. **_重要:_ 编辑 `gacha_session_info.json` 文件:**
    *   用文本编辑器打开 `gacha_session_info.json` 文件。
    *   找到包含 `"UidString": "REPLACE_WITH_YOUR_UID"` 的那一行。
    *   将 `"REPLACE_WITH_YOUR_UID"` 替换为实际的UID。保存文件。
    *   如果没有正确填写软件会回退到原有的逻辑，然后大概会报错。

12. **_重要:_ 关闭系统代理:**
    *   操作完成后，务必返回系统代理设置处（设置 > 网络和互联网 > 代理 > 手动设置代理），**关闭**之前开启的代理服务器，不然会没有网络。

13. **运行第3步编译好的 `ElmoBeacon.exe`** （确认编辑后的`gacha_session_info.json`在同一目录下）。软件会读取json文件并正常同步抽卡记录。

</details>

## Temporary Workaround Instructions for Gacha Record Sync (US/DarkWinter Servers)
**Please Note:**
*   This workaround is primarily intended to fix issues for players on the **US (DarkWinter/Sunborn) server** following recent [game security changes](https://www.reddit.com/r/GirlsFrontline2/comments/1krn8ij/psa_your_password_to_gfl2_is_being_logged_in/).
*   CN server functionality is not addressed.
*   Haoplay *should* still work with the original Player.log parsing method. If you are on these servers and the tracker was working, you might not need these steps unless the log parsing also fails for you.
*   This method uses `mitmproxy` to capture necessary information from your game's network traffic.

<details>
<summary><strong>English Instructions (Click to expand)</strong></summary>

---

**Prerequisites:**
1.  Git ([git-scm.com/downloads](https://git-scm.com/downloads/))
2.  Go ([go.dev/dl/](https://go.dev/dl/))
4.  Wails CLI ([wails.io/docs/gettingstarted/installation](https://wails.io/docs/gettingstarted/installation))
5.  Python 3 ([python.org/downloads/](https://www.python.org/downloads/))
7.  `mitmproxy` (Install via terminal: `pip install mitmproxy`.

---

**Part 1: Build the Fixed Application**
1. **Create a Working Folder:** Make a new folder (e.g., "ElmoBeacon-Fixed"). Optionally, copy your existing `ElmoBeacon.db` into it.
2. **Clone This Repository Branch:**
    *   Open a terminal in your working folder.
    *   Run:
        ```bash
        git clone -b temp-fix-us-auth https://github.com/vitafinn/ElmoBeacon.git
        ```
4.  **Build:**
    *   Navigate into the cloned `ElmoBeacon` directory: `cd ElmoBeacon`
    *   Run: `wails build`
5.  **Move Executable:**
    *   Go to `ElmoBeacon\build\bin\`.
    *   Move the `ElmoBeacon.exe` to your main working folder (e.g., "ElmoBeacon-Fixed").

---

**Part 2: Capture auth info for your account**

7.  **Get Helper Script:**
    *   Find`gfl2_token_extractor.py` inside the `ElmoBeacon` folder you just `git clone`'d. Move it to your working folder (same folder as `ElmoBeacon.exe`)
    *   OR: Download it from: [https://gist.github.com/vitafinn/a0aa2136d58719040731f18629d60bd4](https://gist.github.com/vitafinn/a0aa2136d58719040731f18629d60bd4)
        *   Save it in your working folder (with `ElmoBeacon.exe`).

9.  **Run Helper Script:**
    *   In your terminal (in the working folder), run:
        ```bash
        python gfl2_token_extractor.py
        ```
    *   The script will start `mitmdump` from mitmproxy

10.  **Configure System Proxy & Certificate:**
*   **Proxy:** Set system HTTP/HTTPS proxy to `127.0.0.1`, port `8080`.
    *   *(Windows: Settings > Network & Internet > Proxy > Manual proxy setup)*
*   **Certificate:** While `mitmproxy` runs (the python script), go to `http://mitm.it` in a browser. Download and install the CA certificate into "Trusted Root Certification Authorities" (Windows).
    *   *OR: (Manual install: [docs.mitmproxy.org/stable/concepts/certificates](https://docs.mitmproxy.org/stable/concepts/certificates/#installing-the-mitmproxy-ca-certificate-manually))*

11.  **Trigger Gacha History in Game:**
    Start the game and navigate to the in-game gacha pull history screen for any banner.

12.  **File Generation:**
    *   The script will print captured info and save `gacha_session_info.json` in your working folder.
    *   `mitmproxy` will attempt to shut down (or press `Ctrl+C`).

13. **_IMPORTANT:_ Edit `gacha_session_info.json`:**
    *   Open `gacha_session_info.json`.
    *   Replace `"REPLACE_WITH_YOUR_UID"` in the `UidString` field with your numerical in-game UID. Save.

15. **_IMPORTANT:_ Disable System Proxy:**
    *   Turn OFF your system proxy settings to restore normal internet access.

16. **Run `ElmoBeacon.exe`** from your working folder. It should now sync records.
</details>